### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## What's in this PR?
+
+### Quick summary of the changes you made
+
+### Any necessary explanation of decisions you made
+
+## Before
+
+Description of behaviour before and/or screenshots (where necessary)
+
+## After
+
+Description of behaviour after and/or screenshots (where necessary)
+
+### QA Steps
+
+### QA Checklist
+- [ ] Changes have automated tests
+- [ ] Changes were manually QA'd
+
+### References
+
+### Cat picture
+![cat](https://cataas.com/cat?width=300)


### PR DESCRIPTION
## What's in this PR?
This PR adds GitHub templates for pull requests, bug reports, and feature requests.

### Any necessary explanation of decisions you made
- Copied from https://github.com/C-Flatla/personal_website-DEPRECATED/tree/master/.github for the most part 😄 

## Before
- No templates

## After
- PR template
- Bug report issue template
- Feature request issue template

### QA Checklist
- [x] Changes were manually QA'd

### References
[Github docs](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository)

### Cat picture
![cat](https://cataas.com/cat?width=300)