### PR TITLE
Add netlify badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 <h1 align="center">
   My Personal Website
 </h1>
+
 This project is my own personal website. Here I will tinker around, learn some things, and try to explain a bit about myself.
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/5ed93653-e304-4f0e-a473-db0a1e951d35/deploy-status)](https://app.netlify.com/sites/codyflatla/deploys)
 
 ## 🚀 Quick start
 


### PR DESCRIPTION
## What's in this PR?
This PR adds a Netlify deploy badge to the README

## Before
No badge 😢 

## After
<img width="145" alt="Screen Shot 2020-10-23 at 12 02 46 AM" src="https://user-images.githubusercontent.com/5545625/96961983-1812de00-14c3-11eb-882d-515bd8c8fe10.png">

### QA Checklist
- [x] Changes were manually QA'd

### References
[Netlify docs](https://docs.netlify.com/monitor-sites/status-badges/#add-status-badges)

### Cat picture
![cat](https://cataas.com/cat?width=300)
